### PR TITLE
pdfconverter: Strip trailing slash (/) in folder path

### DIFF
--- a/pdfconverter.py
+++ b/pdfconverter.py
@@ -28,7 +28,7 @@ parser.add_argument("folderName", help="The folder containing images to be conve
 parser.add_argument("start", help="Starting image number to be converted", type=int)
 parser.add_argument("end", help="Last image number to be converted", type=int)
 args = parser.parse_args()
-folderName = args.folderName
+folderName = (args.folderName).strip("/")
 start = args.start
 end = args.end
 


### PR DESCRIPTION
Leaving trailing slashes in the target folder path can lead to unexpected result location.

For example, given `folderName` input as `hvlda-gmxe/` (note the trailing slash), instead of

  ```
   hvlda-gmxe.pdf
  ```

, the PDF result will be located in

  ```
   hvlda-gmxe/.pdf
  ```

Strip the trailing slash from the given folder name input.

Reference: https://stackoverflow.com/a/10408845