### PR TITLE
pdfconverter: Use file path for image conversion

### DIFF
--- a/pdfconverter.py
+++ b/pdfconverter.py
@@ -36,8 +36,7 @@ print("Converting...")
 images = []
 for num in range(start, end+1):
     filepath = "{0}/{1}.jpg".format(folderName, num)
-    with open(filepath, "rb") as image:
-        images.append(image.read())
+    images.append(filepath)
 
 with open("{0}.pdf".format(folderName), "wb") as file:
     file.write(img2pdf.convert(images))


### PR DESCRIPTION
Instead of appending the image content, we could instead use the file path for `img2pdf`. This reduces huge memory consumption during image conversion (tested in 1GB machine, process getting killed if using image content).

File path usage is also documented in the library homepage in PyPI [1].

[1] https://pypi.org/project/img2pdf/